### PR TITLE
Add Gemini white dog image flow with cached URL responses

### DIFF
--- a/image-generation-agent/src/api/routes.ts
+++ b/image-generation-agent/src/api/routes.ts
@@ -1,6 +1,14 @@
 import { registerApiRoute } from '@mastra/core/server';
-import { uploadMultipleImages } from '../utils/r2-storage';
-import type { GenerateImageRequest, GenerateImageResponse } from '../types';
+import {
+  getImageFromCache,
+  saveImageToCache,
+} from '../utils/image-cache';
+import { smartImageRouterTool } from '../mastra/tools/smart-image-router';
+import type {
+  GenerateImageRequest,
+  GenerateImageResponse,
+  GeneratedImage,
+} from '../types';
 
 /**
  * 健康检查路由
@@ -23,17 +31,21 @@ const generateImageRoute = registerApiRoute('/generate-image', {
   method: 'POST',
   handler: async (c) => {
     const startTime = Date.now();
-    
+
     let task_id: string | undefined;
     let prompt: string | undefined;
     let count = 1;
-    
+    let size: '1024x1024' | '1024x1792' | '1792x1024' = '1024x1024';
+    let quality: 'standard' | 'hd' = 'standard';
+
     try {
       const body = await c.req.json<GenerateImageRequest>();
-      
+
       task_id = body.task_id;
       prompt = body.prompt;
       count = body.count ?? 1;
+      size = body.options?.size ?? '1024x1024';
+      quality = body.options?.quality ?? 'standard';
       
       // 验证必需参数
       if (!task_id || !prompt) {
@@ -63,46 +75,85 @@ const generateImageRoute = registerApiRoute('/generate-image', {
       
       console.log(`📥 收到任务: ${task_id}, prompt: "${prompt}", count: ${count}`);
       
-      // TODO: 调用Mastra Agent生成图片
-      // const mastra = c.get('mastra');
-      // const agent = await mastra.getAgent('imageGenerationAgent');
-      // const result = await agent.generate(`生成${count}张图片：${prompt}`);
-      
-      // 临时模拟数据
-      const generatedImages = Array.from({ length: count }, (_, i) => ({
-        url: `https://example.com/temp-${task_id}-${i + 1}.png`,
-      }));
-      
-      console.log(`🎨 图片生成完成，开始上传到R2...`);
-      
-      // 上传到R2（如果在Workers环境中）
-      // const r2Bucket = c.env.IMAGE_STORAGE;
-      // const uploadResults = await uploadMultipleImages(
-      //   r2Bucket,
-      //   task_id,
-      //   generatedImages
-      // );
-      
-      // 临时返回模拟结果
-      const images = generatedImages.map((img, index) => ({
-        index: index + 1,
-        url: img.url,
-        storage_key: `images/temp-${task_id}-${index + 1}.png`,
-      }));
-      
-      const totalTime = (Date.now() - startTime) / 1000;
-      
-      console.log(`✅ 任务完成: ${task_id}, 耗时: ${totalTime.toFixed(2)}s`);
-      
+      const whiteDogKeywords = [/white\s+dog/i, /白色的?狗/, /白狗/];
+      const containsWhiteDog = whiteDogKeywords.some((regex) =>
+        regex.test(prompt!)
+      );
+
+      const enrichedPrompt = containsWhiteDog
+        ? prompt
+        : `${prompt}, featuring a pure white dog with soft fur and friendly expression`;
+
+      const optimizedPrompt = `Create ${count} ultra detailed, high quality images of a pristine white dog. ${enrichedPrompt}. Photorealistic, 4k resolution, cinematic lighting, professional composition.`;
+
+      console.log(
+        `🎨 调用Google Gemini生成图片: task=${task_id}, count=${count}, size=${size}, quality=${quality}`
+      );
+
+      const toolResult = await smartImageRouterTool.execute({
+        context: {
+          optimized_prompt: optimizedPrompt,
+          count,
+          size,
+          quality,
+          force_model: 'google-gemini-image',
+        },
+      });
+
+      const generatedImages: GeneratedImage[] = toolResult.images;
+
+      if (!generatedImages.length) {
+        throw new Error('图像生成失败: 未获得任何有效的图片');
+      }
+
+      const baseUrl = new URL(c.req.url);
+      const origin = `${baseUrl.protocol}//${baseUrl.host}`;
+
+      const images = generatedImages.map((image, index) => {
+        const imageIndex = index + 1;
+        let publicUrl = image.uri;
+        let storageKey = image.uri
+          ? `gemini://${image.model_used}/${task_id}/${imageIndex}`
+          : `cache://${task_id}/${imageIndex}`;
+
+        const base64Payload = image.base64;
+        if (!publicUrl && base64Payload) {
+          const normalizedBase64 = base64Payload.startsWith('data:')
+            ? base64Payload
+            : `data:${image.mime_type};base64,${base64Payload}`;
+
+          saveImageToCache(task_id!, imageIndex, normalizedBase64, image.mime_type);
+          publicUrl = `${origin}/images/${task_id}/${imageIndex}`;
+        }
+
+        if (!publicUrl) {
+          throw new Error('图像生成失败: 无法为生成的图片创建可访问链接');
+        }
+
+        return {
+          index: imageIndex,
+          url: publicUrl,
+          storage_key: storageKey,
+        };
+      });
+
+      const generationTime = toolResult.generation_time ?? (Date.now() - startTime) / 1000;
+
+      console.log(
+        `✅ 任务完成: ${task_id}, 成功生成${images.length}张图片, 耗时: ${generationTime.toFixed(
+          2
+        )}s`
+      );
+
       return c.json<GenerateImageResponse>({
         success: true,
         task_id,
         total_images: images.length,
-        images: images,
-        generation_time: totalTime,
+        images,
+        generation_time: generationTime,
         expires_at: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
         metadata: {
-          prompt,
+          prompt: optimizedPrompt,
           requested_count: count,
           actual_count: images.length,
         },
@@ -122,6 +173,35 @@ const generateImageRoute = registerApiRoute('/generate-image', {
         },
       }, 500);
     }
+  },
+});
+
+const cachedImageRoute = registerApiRoute('/images/:taskId/:imageIndex', {
+  method: 'GET',
+  handler: async (c) => {
+    const { taskId, imageIndex } = c.req.param();
+
+    if (!taskId || !imageIndex) {
+      return new Response('Missing parameters', { status: 400 });
+    }
+
+    const parsedIndex = Number.parseInt(imageIndex, 10);
+    if (Number.isNaN(parsedIndex) || parsedIndex <= 0) {
+      return new Response('Invalid image index', { status: 400 });
+    }
+
+    const cached = getImageFromCache(taskId, parsedIndex);
+    if (!cached) {
+      return new Response('Image not found', { status: 404 });
+    }
+
+    return new Response(cached.buffer, {
+      status: 200,
+      headers: {
+        'Content-Type': cached.mimeType,
+        'Cache-Control': 'public, max-age=300',
+      },
+    });
   },
 });
 
@@ -145,6 +225,7 @@ const generateBatchRoute = registerApiRoute('/generate-batch', {
 export const routes = [
   healthRoute,
   generateImageRoute,
+  cachedImageRoute,
   generateBatchRoute,
 ];
 

--- a/image-generation-agent/src/mastra/tools/smart-image-router.ts
+++ b/image-generation-agent/src/mastra/tools/smart-image-router.ts
@@ -5,8 +5,7 @@ import { GoogleGenAI } from '@google/genai';
 const GOOGLE_GEMINI_IMAGE_MODEL = 'models/gemini-2.5-flash-image';
 const MAX_IMAGES_PER_REQUEST = 4;
 
-const googleApiKey =
-  process.env.GOOGLE_API_KEY ;
+const googleApiKey = process.env.GOOGLE_API_KEY || process.env.GOOGLE_GENAI_API_KEY;
 
 const geminiImageClient = new GoogleGenAI({
   apiKey: googleApiKey || undefined,
@@ -39,7 +38,7 @@ const extractErrorMessage = (error: unknown): string => {
 export const smartImageRouterTool = createTool({
   id: 'smart-image-router',
   description:
-    '使用 Google Gemini 2.5 Flash Image 自动生成高质量图像，支持根据请求数量批量生成并返回 base64 数据 URL',
+    '使用 Google Gemini 2.5 Flash Image 自动生成高质量图像，支持根据请求数量批量生成并返回可访问的图片链接',
 
   inputSchema: z.object({
     optimized_prompt: z.string().describe('已经优化过的高质量prompt'),
@@ -63,9 +62,14 @@ export const smartImageRouterTool = createTool({
       .describe('保持向后兼容，目前仅支持Google Gemini图像模型'),
   }),
   outputSchema: z.object({
-     images: z.array(
+    images: z.array(
       z.object({
-        url: z.string().describe('图片URL或base64'),
+        uri: z.string().optional().describe('图片的直接访问链接'),
+        base64: z.string().optional().describe('图片的base64数据（用于后续存储或缓存）'),
+        mime_type: z
+          .string()
+          .default('image/png')
+          .describe('图片的MIME类型'),
         model_used: z.string().describe('使用的模型'),
         revised_prompt: z.string().optional().describe('模型修订后的prompt'),
       }),
@@ -81,7 +85,13 @@ export const smartImageRouterTool = createTool({
     }
 
     const startTime = Date.now();
-    const images: Array<{ url: string; model_used: string; revised_prompt?: string }> = [];
+    const images: Array<{
+      uri?: string;
+      base64?: string;
+      mime_type: string;
+      model_used: string;
+      revised_prompt?: string;
+    }> = [];
      const targetCount = Math.min(count, MAX_IMAGES_PER_REQUEST);
     const aspectRatio = aspectRatioMap[size];
     try {
@@ -97,12 +107,23 @@ export const smartImageRouterTool = createTool({
 
       for (const generatedImage of response.generatedImages ?? []) {
         const imagePayload = generatedImage.image;
-        if (!imagePayload?.imageBytes) {
+        if (!imagePayload) {
           continue;
         }
-         const mimeType = imagePayload.mimeType || 'image/png';
+
+        const mimeType = imagePayload.mimeType || 'image/png';
+        const base64 = imagePayload.imageBytes;
+        const uri = (imagePayload as { uri?: string; contentUri?: string }).uri ||
+          (imagePayload as { uri?: string; contentUri?: string }).contentUri;
+
+        if (!base64 && !uri) {
+          continue;
+        }
+
         images.push({
-          url: `data:${mimeType};base64,${imagePayload.imageBytes}`,
+          uri: uri || undefined,
+          base64: base64 || undefined,
+          mime_type: mimeType,
           model_used: GOOGLE_GEMINI_IMAGE_MODEL,
         });
       }

--- a/image-generation-agent/src/types/index.ts
+++ b/image-generation-agent/src/types/index.ts
@@ -62,7 +62,9 @@ export interface GenerateImageResponse {
  * 生成的图片信息
  */
 export interface GeneratedImage {
-  url: string;
+  uri?: string;
+  base64?: string;
+  mime_type: string;
   model_used: string;
   revised_prompt?: string;
 }

--- a/image-generation-agent/src/utils/image-cache.ts
+++ b/image-generation-agent/src/utils/image-cache.ts
@@ -1,0 +1,87 @@
+const DEFAULT_TTL_MS = 30 * 60 * 1000;
+
+type CacheKey = `${string}#${number}`;
+
+interface CachedImage {
+  buffer: Uint8Array;
+  mimeType: string;
+  expiresAt: number;
+}
+
+const imageCache = new Map<CacheKey, CachedImage>();
+
+function buildKey(taskId: string, imageIndex: number): CacheKey {
+  return `${taskId}#${imageIndex}`;
+}
+
+function cleanupExpired(now = Date.now()): void {
+  for (const [key, value] of imageCache.entries()) {
+    if (value.expiresAt <= now) {
+      imageCache.delete(key);
+    }
+  }
+}
+
+function stripDataUrlPrefix(base64: string): string {
+  return base64.replace(/^data:[^;]+;base64,/, '');
+}
+
+function decodeBase64(base64: string): Uint8Array {
+  if (typeof Buffer !== 'undefined') {
+    return Uint8Array.from(Buffer.from(base64, 'base64'));
+  }
+
+  const binaryString = atob(base64);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes;
+}
+
+export function saveImageToCache(
+  taskId: string,
+  imageIndex: number,
+  base64Data: string,
+  mimeType: string,
+  ttlMs: number = DEFAULT_TTL_MS
+): void {
+  cleanupExpired();
+
+  const pureBase64 = stripDataUrlPrefix(base64Data);
+  const buffer = decodeBase64(pureBase64);
+
+  imageCache.set(buildKey(taskId, imageIndex), {
+    buffer,
+    mimeType,
+    expiresAt: Date.now() + ttlMs,
+  });
+}
+
+export function getImageFromCache(
+  taskId: string,
+  imageIndex: number
+): { buffer: Uint8Array; mimeType: string } | undefined {
+  cleanupExpired();
+
+  const cached = imageCache.get(buildKey(taskId, imageIndex));
+  if (!cached) {
+    return undefined;
+  }
+
+  if (cached.expiresAt <= Date.now()) {
+    imageCache.delete(buildKey(taskId, imageIndex));
+    return undefined;
+  }
+
+  return { buffer: cached.buffer, mimeType: cached.mimeType };
+}
+
+export function removeImageFromCache(taskId: string, imageIndex: number): void {
+  imageCache.delete(buildKey(taskId, imageIndex));
+}
+
+export function getCachedImageCount(): number {
+  cleanupExpired();
+  return imageCache.size;
+}


### PR DESCRIPTION
## Summary
- route Gemini image generation through the smart router tool with an enriched white dog prompt and URL-based responses
- add an in-memory cache and delivery endpoint so generated images can be fetched without exposing base64 payloads
- extend the Gemini tool output to surface URIs, mime types, and base64 fallbacks for downstream storage

## Testing
- npm run dev *(fails: `mastra` CLI not found because npm install cannot complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e36dd295888330b3fd9d88d8f72590