### PR TITLE
Refine Wrangler configuration for Cloudflare deployment

### DIFF
--- a/image-generation-agent/src/mastra/agents/image-agent.ts
+++ b/image-generation-agent/src/mastra/agents/image-agent.ts
@@ -55,7 +55,7 @@ export const imageGenerationAgent = new Agent({
 - **⭐ 生成完成后，必须明确告诉用户：**
   1. ✅ 图片生成成功
   2. 📊 生成了多少张图片
-  3. 📁 图片保存在哪个目录（从工具返回的 output_directory）
+  3. 📁 图片保存在哪个目录（使用工具返回的 R2 地址，即 smartImageRouterTool 返回的 URL）
   4. 📄 文件名是什么
   5. ⏱️ 生成耗时
 
@@ -64,7 +64,7 @@ export const imageGenerationAgent = new Agent({
 
 ✅ 生成成功！
 📊 共生成 1 张图片
-📁 保存位置: /your/path/output/
+📁 保存位置: <smartImageRouterTool 返回的 R2 URL>
 📄 文件名: gemini_1728356789123_1.png
 ⏱️ 耗时: 3.2 秒
 

--- a/image-generation-agent/wrangler.toml
+++ b/image-generation-agent/wrangler.toml
@@ -1,63 +1,86 @@
 name = "image-generation-agent"
+# 替换为你的 Cloudflare 账号 ID
+account_id = "YOUR_CLOUDFLARE_ACCOUNT_ID"
+
 main = "workers/index.ts"
 compatibility_date = "2024-10-01"
 node_compat = true
 
-# Workers 配置
+# 默认启用 workers.dev 预览域名，方便开发/调试
 workers_dev = true
-route = ""
-zone_id = ""
 
-# 资源限制
-[limits]
-cpu_ms = 50000  # 50秒 CPU 时间
+# ============================================
+# 构建与部署配置
+# ============================================
+[build]
+command = "npm run build"
+watch_dir = ["src", "workers"]
 
-# R2 Bucket 绑定
+# ============================================
+# R2 Bucket 绑定（默认环境）
+# ============================================
 [[r2_buckets]]
 binding = "IMAGE_STORAGE"
 bucket_name = "image-agent-storage"
 
-# 环境变量（非敏感信息）
+# ============================================
+# 默认环境变量（可根据需要覆盖）
+# 将 R2_PUBLIC_URL 替换为你的公开访问域名
+# 例：https://pub-xxxxx.r2.dev 或 https://images.example.com
+# ============================================
 [vars]
 NODE_ENV = "production"
+R2_PUBLIC_URL = "https://your-r2-public-domain"
 
-# R2 公开 URL（根据你的实际配置修改）
-# 方式1: 使用 R2.dev 子域名
-# R2_PUBLIC_URL = "https://pub-xxxxx.r2.dev"
-# 方式2: 使用自定义域名
-# R2_PUBLIC_URL = "https://images.yourdomain.com"
-
-# 开发环境
+# ============================================
+# 开发环境（wrangler dev --env development）
+# ============================================
 [env.development]
 name = "image-generation-agent-dev"
-vars = { NODE_ENV = "development" }
+workers_dev = true
+vars = { NODE_ENV = "development", R2_PUBLIC_URL = "http://127.0.0.1:8787/output" }
 
-# 开发环境 R2
 [[env.development.r2_buckets]]
 binding = "IMAGE_STORAGE"
 bucket_name = "image-agent-storage-dev"
 
-# 生产环境
+# ============================================
+# 预发布环境（可选）
+# 部署：wrangler deploy --env preview
+# ============================================
+[env.preview]
+name = "image-generation-agent-preview"
+workers_dev = true
+vars = { NODE_ENV = "preview", R2_PUBLIC_URL = "https://preview-r2-domain.example.com" }
+
+[[env.preview.r2_buckets]]
+binding = "IMAGE_STORAGE"
+bucket_name = "image-agent-storage-preview"
+
+# ============================================
+# 生产环境（正式部署）
+# 部署：wrangler deploy --env production
+# 将 pattern 替换为你的自定义域名路由
+# 将 zone_id 替换为域名对应的 Zone ID
+# ============================================
 [env.production]
 name = "image-generation-agent-prod"
-vars = { NODE_ENV = "production" }
+workers_dev = false
+zone_id = "YOUR_ZONE_ID"
+vars = { NODE_ENV = "production", R2_PUBLIC_URL = "https://your-r2-public-domain" }
 
-# 生产环境 R2
+[[env.production.routes]]
+pattern = "api.example.com/*"
+custom_domain = true
+
 [[env.production.r2_buckets]]
 binding = "IMAGE_STORAGE"
 bucket_name = "image-agent-storage"
 
 # ============================================
-# 敏感信息通过 wrangler secret 命令设置
-# ============================================
-# 
-# 本地开发使用 .env 文件
-# 生产环境使用以下命令设置 secrets：
-#
-# wrangler secret put GOOGLE_API_KEY
-# wrangler secret put R2_PUBLIC_URL
-#
-# 注意：R2_PUBLIC_URL 格式示例：
-# - R2.dev: https://pub-xxxxx.r2.dev
-# - 自定义域名: https://images.yourdomain.com
+# 提示：敏感信息使用 wrangler secret 管理
+#   wrangler secret put MOONSHOT_API_KEY
+#   wrangler secret put OPENAI_API_KEY
+#   wrangler secret put R2_ACCESS_KEY_ID
+#   wrangler secret put R2_SECRET_ACCESS_KEY
 # ============================================


### PR DESCRIPTION
## Summary
- add Cloudflare account scaffolding and build/watch configuration to `wrangler.toml`
- document R2 public domain placeholders and align default/development environment variables
- introduce preview and production environment sections with route guidance and bucket bindings

## Testing
- not run (config change only)

------
https://chatgpt.com/codex/tasks/task_e_68e7501f94648330954cbecb52867fd7