### PR TITLE
Remove local image backups from smart image router

### DIFF
--- a/image-generation-agent/src/api/routes.ts
+++ b/image-generation-agent/src/api/routes.ts
@@ -107,31 +107,33 @@ export const generateImageRoute = registerApiRoute('/generate-image', {
         const uploadResults = await uploadMultipleImages(
           r2Bucket,
           task_id,
-          generationResult.images,
+          generationResult.images.map((img) => ({
+            url: `data:image/png;base64,${img.base64_data}`,
+          })),
           r2PublicUrl
         );
-        
+
         if (uploadResults.length > 0) {
           console.log(`✅ R2 上传完成: ${uploadResults.length}/${generationResult.total_count} 张`);
           finalImages = uploadResults;
         } else {
-          console.warn(`⚠️  R2 上传全部失败，使用本地路径`);
-          // 使用本地路径作为备选
+          console.warn(`⚠️  R2 上传全部失败，使用内嵌 data URL`);
+          // 使用 data URL 作为备选
           finalImages = generationResult.images.map((img, index) => ({
             index: index + 1,
-            url: img.local_path,
-            storage_key: img.local_path,
+            url: img.url,
+            storage_key: img.r2_key || '',
             file_name: img.file_name,
             size_bytes: 0,
           }));
         }
       } else {
-        // 没有配置 R2，使用本地路径
-        console.log(`💾 使用本地存储模式`);
+        // 没有配置 R2，使用 data URL
+        console.log(`💾 使用内嵌 data URL 模式`);
         finalImages = generationResult.images.map((img, index) => ({
           index: index + 1,
-          url: img.url, // 这里可能是本地路径或者 R2 URL（如果在工具中已经上传）
-          storage_key: img.r2_key || img.local_path,
+          url: img.url,
+          storage_key: img.r2_key || '',
           file_name: img.file_name,
           size_bytes: 0,
         }));

--- a/image-generation-agent/src/mastra/tools/smart-image-router.ts
+++ b/image-generation-agent/src/mastra/tools/smart-image-router.ts
@@ -1,8 +1,6 @@
 import { createTool } from '@mastra/core/tools';
 import { z } from 'zod';
 import { GoogleGenAI } from '@google/genai';
-import * as fs from 'fs';
-import * as path from 'path';
 import { uploadToR2, isR2Configured } from '../../utils/r2-uploader';
 
 const GOOGLE_GEMINI_IMAGE_MODEL = 'gemini-2.5-flash-image';
@@ -20,31 +18,6 @@ const resolveGoogleApiKey = (): string | undefined => {
 
   return undefined;
 };
-
-/**
- * 确保本地输出目录存在（作为备份）
- */
-function ensureOutputDirectory(): string {
-  const outputDir = path.join(process.cwd(), 'output');
-  if (!fs.existsSync(outputDir)) {
-    fs.mkdirSync(outputDir, { recursive: true });
-  }
-  return outputDir;
-}
-
-/**
- * 保存图片到本地（备份）
- */
-function saveImageToFile(base64Data: string, outputDir: string, index: number): string {
-  const timestamp = Date.now();
-  const fileName = `gemini_${timestamp}_${index}.png`;
-  const filePath = path.join(outputDir, fileName);
-  
-  const imageBuffer = Buffer.from(base64Data, 'base64');
-  fs.writeFileSync(filePath, imageBuffer);
-  
-  return filePath;
-}
 
 const extractErrorMessage = (error: unknown): string => {
   if (!error) return '';
@@ -86,17 +59,16 @@ export const smartImageRouterTool = createTool({
   outputSchema: z.object({
     images: z.array(
       z.object({
-        url: z.string().describe('图片的公开 URL（Cloudflare R2 或本地）'),
+        url: z.string().describe('图片的公开 URL（Cloudflare R2 或内嵌 data URL）'),
         r2_key: z.string().optional().describe('R2 存储路径'),
-        local_path: z.string().describe('本地备份路径'),
         file_name: z.string().describe('文件名'),
-        storage_type: z.enum(['r2', 'local']).describe('存储类型'),
+        storage_type: z.enum(['r2', 'inline']).describe('存储类型'),
         model_used: z.string().describe('使用的模型'),
+        base64_data: z.string().describe('Base64 编码的图片数据'),
       }),
     ),
     total_count: z.number(),
     generation_time: z.number().describe('生成耗时（秒）'),
-    output_directory: z.string().describe('本地输出目录'),
   }),
   
   execute: async ({ context }) => {
@@ -114,17 +86,14 @@ export const smartImageRouterTool = createTool({
     const images: Array<{
       url: string;
       r2_key?: string;
-      local_path: string;
       file_name: string;
-      storage_type: 'r2' | 'local';
+      storage_type: 'r2' | 'inline';
       model_used: string;
+      base64_data: string;
     }> = [];
     const targetCount = Math.min(count, MAX_IMAGES_PER_REQUEST);
     const taskId = `task_${Date.now()}`;
-    
-    // 确保本地输出目录存在（作为备份）
-    const outputDir = ensureOutputDirectory();
-    
+
     // 检查 R2 是否已配置
     const hasR2 = isR2Configured();
     
@@ -157,20 +126,17 @@ export const smartImageRouterTool = createTool({
                 if (part.inlineData && part.inlineData.data) {
                   const imageData = part.inlineData.data;
                   
-                  // 1. 保存到本地（备份）
-                  const localPath = saveImageToFile(imageData, outputDir, images.length + 1);
-                  const fileName = path.basename(localPath);
-                  console.log(`💾 本地备份: ${localPath}`);
-                  
-                  let finalUrl = localPath;
-                  let storageType: 'r2' | 'local' = 'local';
+                  const fileName = `gemini_${Date.now()}_${images.length + 1}.png`;
+                  const inlineUrl = `data:image/png;base64,${imageData}`;
+
+                  let finalUrl = inlineUrl;
+                  let storageType: 'r2' | 'inline' = 'inline';
                   let r2Key: string | undefined = undefined;
-                  
-                  // 2. 上传到 R2（如果配置了）
+
                   if (hasR2) {
                     console.log(`☁️  正在上传到 Cloudflare R2...`);
                     const uploadResult = await uploadToR2(imageData, taskId, images.length + 1);
-                    
+
                     if (uploadResult.success) {
                       finalUrl = uploadResult.url;
                       r2Key = uploadResult.key;
@@ -179,17 +145,17 @@ export const smartImageRouterTool = createTool({
                       console.log(`🔗 公开 URL: ${finalUrl}`);
                     } else {
                       console.warn(`⚠️  R2 上传失败: ${uploadResult.error}`);
-                      console.warn(`⚠️  将使用本地路径`);
+                      console.warn(`⚠️  将使用内嵌 data URL`);
                     }
                   }
-                  
+
                   images.push({
                     url: finalUrl,
                     r2_key: r2Key,
-                    local_path: localPath,
                     file_name: fileName,
                     storage_type: storageType,
                     model_used: GOOGLE_GEMINI_IMAGE_MODEL,
+                    base64_data: imageData,
                   });
                 }
               }
@@ -207,9 +173,8 @@ export const smartImageRouterTool = createTool({
       console.log(`\n🎉 生成完成！`);
       console.log(`📊 总数: ${images.length} 张`);
       console.log(`⏱️  耗时: ${generationTime.toFixed(2)} 秒`);
-      console.log(`💾 存储: ${hasR2 ? 'Cloudflare R2 + 本地备份' : '本地'}`);
-      console.log(`📁 本地目录: ${outputDir}\n`);
-      
+      console.log(`💾 存储: ${hasR2 ? 'Cloudflare R2' : '内嵌 data URL'}`);
+
       // 打印所有图片的 URL
       images.forEach((img, idx) => {
         console.log(`图片 ${idx + 1}:`);
@@ -217,14 +182,13 @@ export const smartImageRouterTool = createTool({
         if (img.r2_key) {
           console.log(`  ☁️  R2 Key: ${img.r2_key}`);
         }
-        console.log(`  💾 本地: ${img.local_path}\n`);
+        console.log(`  💾 存储类型: ${img.storage_type}\n`);
       });
-      
+
       return {
         images,
         total_count: images.length,
         generation_time: generationTime,
-        output_directory: outputDir,
       };
     } catch (error) {
       const message = extractErrorMessage(error);


### PR DESCRIPTION
## Summary
- remove filesystem output handling from the smart image router tool and rely on inline data URLs instead
- keep base64 payloads in the tool response so callers can upload to R2 without touching disk
- update the generate-image route to transform inline data when uploading or falling back to inline responses

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8b66fbe1c833080ec7eab4e434ba5